### PR TITLE
Add support for updating existing models

### DIFF
--- a/packages/modeltyped-core/lib/typeDefinition.ts
+++ b/packages/modeltyped-core/lib/typeDefinition.ts
@@ -1,7 +1,13 @@
 export interface TypeDefinition<Input, Instance, Output = Input> {
     fromJSON: (t: Input) => Instance;
     toJSON: (u: Instance) => Output;
+    update?: (newVal: Input, prevVal: Instance) => Instance;
 }
+
+export const updateType = <Input, Instance, Output>(
+    t: TypeDefinition<Input, Instance, Output>,
+    { oldValue, newValue }: { oldValue: Instance; newValue: Input },
+) => (t.update ? t.update(newValue, oldValue) : t.fromJSON(newValue));
 
 // Utility types for extracting the type params from TypeDefinition
 export type TypeDefInput<
@@ -13,7 +19,3 @@ export type TypeDefInstance<
 export type TypeDefOutput<
     T extends TypeDefinition<any, any, any>
 > = T extends TypeDefinition<any, any, infer O> ? O : never;
-
-// Right now, rollup-plugin-typescript2 isn't emitting typings for types-only files.
-// As a temporary hack, add a pointless export here
-export const __typeDefRollupHack = true;

--- a/packages/modeltyped-core/lib/types.ts
+++ b/packages/modeltyped-core/lib/types.ts
@@ -3,6 +3,7 @@ import {
     TypeDefInput,
     TypeDefOutput,
     TypeDefInstance,
+    updateType,
 } from "./typeDefinition";
 import {
     ModelDefinition,
@@ -73,6 +74,15 @@ export function record<
             mapValues(obj, ({ fromJSON }, key) => fromJSON(input[key])),
         toJSON: output =>
             mapValues(obj, ({ toJSON }, key) => toJSON(output[key])),
+        // Keep the same object, but update its props with updated values
+        update: (newValues, self) =>
+            (Object.keys(obj) as Array<keyof Obj>).reduce((self, key) => {
+                const typeDef = obj[key];
+                const oldValue = self[key];
+                const newValue = newValues[key];
+                self[key] = updateType(typeDef, { oldValue, newValue });
+                return self;
+            }, self),
     };
 }
 
@@ -93,5 +103,6 @@ export function model<M extends ModelDefinition<any, any>>(
     return {
         fromJSON: input => Model.create(input),
         toJSON: model => model.toJSON(),
+        update: (newData, prevModel) => prevModel.update(newData),
     };
 }

--- a/packages/modeltyped-core/tests/buildModel.test.ts
+++ b/packages/modeltyped-core/tests/buildModel.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { buildModel, types } from "../lib/modeltyped";
+import { buildModel, types, TypeDefinition } from "../lib/modeltyped";
 
 const { string: stringT, optional: optionalT, number: numberT } = types;
 
@@ -88,4 +88,38 @@ test("can define extras that reference other extras", t => {
     const model = TestModel.create({ value: "hodor" });
     t.assert(model.loudValue === "HODOR");
     t.assert(model.loudValueTwice === "HODOR HODOR");
+});
+
+test("can update the model with new data", t => {
+    const model = buildModel({
+        foo: stringT,
+        bar: numberT,
+    }).create({
+        foo: "foo",
+        bar: 0,
+    });
+
+    model.update({ foo: "FOO", bar: 1 });
+
+    t.deepEqual(model.toJSON(), {
+        foo: "FOO",
+        bar: 1,
+    });
+});
+
+const appendOnUpdate: TypeDefinition<string, string> = {
+    toJSON: s => s,
+    fromJSON: s => s,
+    update: (newVal, oldVal) => oldVal + newVal,
+};
+
+test("types can specify custom update logic", t => {
+    const model = buildModel({
+        foo: appendOnUpdate,
+    }).create({
+        foo: "Foo",
+    });
+
+    model.update({ foo: "Bar" });
+    t.is(model.foo, "FooBar");
 });


### PR DESCRIPTION
This allows an existing model to be hydrated with new data, without throwing the model away and creating a new one, which is necessary for certain use-cases.  

`TypeDefinitions` can now specify update functions to control update behavior; if not, the type is just replaced with a new value.  `record` and `model` are the only types that support "smart" updating out of the box.  